### PR TITLE
delay rejection too by default - fixes #1

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,19 @@
 'use strict';
 const delay = require('delay');
 
-module.exports = (promise, ms) => Promise.all([promise, delay(ms)]).then(x => x[0]);
+module.exports = (promise, ms, opts) => {
+	opts = Object.assign({
+		delayRejection: true
+	}, opts);
+
+	let promiseErr;
+
+	if (opts.delayRejection) {
+		promise = promise.catch(err => {
+			promiseErr = err;
+		});
+	}
+
+	return Promise.all([promise, delay(ms)])
+		.then(val => promiseErr ? Promise.reject(promiseErr) : val[0]);
+};

--- a/readme.md
+++ b/readme.md
@@ -19,19 +19,15 @@ $ npm install --save p-min-delay
 ```js
 const pMinDelay = require('p-min-delay');
 
-pMinDelay(somePromise, 1000)
-	.then(value => {
-		// executed after minimum 1 second even if `somePromise` fulfills before that
-	})
-	.catch(error => {
-		// executed right away regardless of delay if `somePromise` rejects
-	});
+pMinDelay(somePromise, 1000).then(value => {
+	// executed after minimum 1 second even if `somePromise` fulfills before that
+});
 ```
 
 
 ## API
 
-### pMinDelay(input, minimumDelay)
+### pMinDelay(input, minimumDelay, [options])
 
 #### input
 
@@ -44,6 +40,19 @@ Promise to delay.
 Type: `number`
 
 Time in milliseconds.
+
+#### options
+
+Type: `Object`
+
+##### delayRejection
+
+Type: `boolean`<br>
+Default: `true`
+
+Delay the rejection.
+
+Turn this off if you want a rejected promise to fail fast.
 
 
 ## Related

--- a/test.js
+++ b/test.js
@@ -1,4 +1,4 @@
-import test from 'ava';
+import {serial as test} from 'ava';
 import delay from 'delay';
 import timeSpan from 'time-span';
 import inRange from 'in-range';
@@ -19,8 +19,14 @@ test('promise takes longer than minimum delay', async t => {
 	t.true(inRange(end(), 170, 230));
 });
 
-test('minimum delay does not apply when rejected', async t => {
+test('minimum delay applies to rejection too', async t => {
 	const end = timeSpan();
 	await m(Promise.reject(), 100).catch(() => {});
+	t.true(inRange(end(), 70, 130));
+});
+
+test('option - {delayRejection:false}', async t => {
+	const end = timeSpan();
+	await m(Promise.reject(), 100, {delayRejection: false}).catch(() => {});
 	t.true(inRange(end(), 0, 30));
 });


### PR DESCRIPTION
I haven't decided whether to make it false or true by default. All other promise methods fail fast, so I think it would maybe be surprising for this to delay the rejection by default. Thoughts?