### PR TITLE
Simplify

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,21 +1,9 @@
 import delay from 'yoctodelay';
 
 export default async function pMinDelay(promise, minimumDelay, {delayRejection = true} = {}) {
-	let promiseError;
-
-	if (delayRejection) {
-		// TODO: Use try/catch here.
-		// eslint-disable-next-line promise/prefer-await-to-then
-		promise = promise.catch(error => {
-			promiseError = error;
-		});
-	}
-
-	const [value] = await Promise.all([promise, delay(minimumDelay)]);
-
-	if (promiseError) {
-		throw promiseError;
-	}
-
-	return value;
+	await Promise[delayRejection ? 'allSettled' : 'all']([
+		promise,
+		delay(minimumDelay),
+	]);
+	return promise;
 }

--- a/index.js
+++ b/index.js
@@ -3,7 +3,8 @@ import delay from 'yoctodelay';
 export default async function pMinDelay(promise, minimumDelay, {delayRejection = true} = {}) {
 	await Promise[delayRejection ? 'allSettled' : 'all']([
 		promise,
-		delay(minimumDelay),
+		delay(minimumDelay)
 	]);
+
 	return promise;
 }


### PR DESCRIPTION
We can return the original promise instead of returning the result. It's much simplier.