### PR TITLE
Remove unnecessary `Promise.allSettled()`

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,10 +1,7 @@
 import delay from 'yoctodelay';
 
 export default async function pMinDelay(promise, minimumDelay, {delayRejection = true} = {}) {
-	await Promise[delayRejection ? 'allSettled' : 'all']([
-		promise,
-		delay(minimumDelay)
-	]);
-
+	const delayPromise = delay(minimumDelay);
+	await (delayRejection ? delayPromise : Promise.all([promise, delayPromise]));
 	return promise;
 }

--- a/test.js
+++ b/test.js
@@ -6,7 +6,7 @@ import pMinDelay from './index.js';
 
 const fixture = Symbol('fixture');
 
-test('only settles after minumum delay', async t => {
+test('only settles after minimum delay', async t => {
 	const end = timeSpan();
 	const result = await pMinDelay(Promise.resolve(fixture), 200);
 	t.is(result, fixture);


### PR DESCRIPTION
When `delayRejection: true`, we don't need to wait for the promise to settle, we can simply just delay and return it back.