### PR TITLE
Add test for non-promise object

### DIFF
--- a/test.js
+++ b/test.js
@@ -13,6 +13,13 @@ test('only settles after minumum delay', async t => {
 	t.true(inRange(end(), {start: 170, end: 230}));
 });
 
+test('accept non-promise object', async t => {
+	const end = timeSpan();
+	const result = await pMinDelay(fixture, 200);
+	t.is(result, fixture);
+	t.true(inRange(end(), {start: 170, end: 230}));
+});
+
 test('promise takes longer than minimum delay', async t => {
 	const end = timeSpan();
 	await pMinDelay(delay(200), 100);


### PR DESCRIPTION
I just realized that #21 changes how we handle the input value, we removed calling `promise.catch`, so the function works for non-Promise objects too.

Let's add a test for it?