### PR TITLE
Replace Promise.all() with Promise.resolve()

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,6 @@
 import delay from 'yoctodelay';
 
 export default async function pMinDelay(promise, minimumDelay, {delayRejection = true} = {}) {
-	const delayPromise = delay(minimumDelay);
-	await (delayRejection ? delayPromise : Promise.all([promise, delayPromise]));
+	await (delayRejection ? delay(minimumDelay) : Promise.resolve(promise));
 	return promise;
 }


### PR DESCRIPTION
We don't need to settle both promises (the one provided as an argument and the delay); rather, we only need to address the one submitted as an argument