### PR TITLE
deps：Update yoctodelay to 2.0.0 for pure esm

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
 		"bluebird"
 	],
 	"dependencies": {
-		"yoctodelay": "^1.2.0"
+		"yoctodelay": "^2.0.0"
 	},
 	"devDependencies": {
 		"ava": "^5.2.0",


### PR DESCRIPTION
I found the dependency `yoctodelay` is not a pure esm

```
ERROR in ./node_modules/p-min-delay/index.js
  × ESModulesLinkingError: export 'default' (imported as 'delay') was not found in 'yoctodelay' (module has no exports)
    ╭─[20:35]
 18 │                 case 0:
 19 │                     _ref = _arguments.length > 2 && _arguments[2] !== void 0 ? _arguments[2] : {}, _ref_delayRejection = _ref.delayRejection, delayRejection = _ref_delayRejection === void 0 ? true : _ref_delayRejection;
 20 │                     delayPromise = delay(minimumDelay);
    ·                                    ─────
 21 │                     return [
 22 │                         4,
    ╰────
```